### PR TITLE
Create Angular + Leaflet dashboard skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# mdm-dashboard
+# MDM Dashboard
+
+Este proyecto es un ejemplo de tablero de monitoreo en Angular y Leaflet que consume los servicios del backend [`mdm-backend`](https://github.com/Luizzavala/mdm-backend).
+
+## Instalación
+
+1. Instale las dependencias con `npm install`.
+2. Inicie el servidor de desarrollo con `npm start`.
+
+## Uso
+
+En el tablero se puede seleccionar un dispositivo para consultar su historial de ubicaciones. Si la última sincronización fue hace más de 20 minutos el dispositivo se marca como **inactivo**. En el mapa se muestran todos los puntos históricos y se resalta la última posición.
+
+## Nota
+
+Debido a las restricciones del entorno, es posible que deba configurar la instalación de dependencias manualmente antes de ejecutar el proyecto.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "mdm-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "webpack serve --open",
+    "build": "webpack",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "@angular/animations": "17.3.10",
+    "@angular/common": "17.3.10",
+    "@angular/compiler": "17.3.10",
+    "@angular/core": "17.3.10",
+    "@angular/forms": "17.3.10",
+    "@angular/platform-browser": "17.3.10",
+    "@angular/platform-browser-dynamic": "17.3.10",
+    "@angular/router": "17.3.10",
+    "rxjs": "7.8.1",
+    "zone.js": "0.14.2",
+    "leaflet": "1.9.4"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "ts-loader": "9.5.0",
+    "webpack": "5.91.0",
+    "webpack-cli": "5.1.4",
+    "webpack-dev-server": "4.13.1",
+    "html-webpack-plugin": "5.5.0"
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { importProvidersFrom } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { DashboardComponent } from './dashboard.component';
+
+const routes: Routes = [{ path: '', component: DashboardComponent }];
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  template: '<router-outlet></router-outlet>',
+  providers: [
+    provideHttpClient(),
+    importProvidersFrom(RouterModule.forRoot(routes))
+  ]
+})
+export class AppComponent { }

--- a/src/app/dashboard.component.css
+++ b/src/app/dashboard.component.css
@@ -1,0 +1,7 @@
+.container {
+  padding: 1rem;
+}
+.map {
+  height: 500px;
+  margin-top: 1rem;
+}

--- a/src/app/dashboard.component.html
+++ b/src/app/dashboard.component.html
@@ -1,0 +1,9 @@
+<div class="container">
+  <h1>MDM Dashboard</h1>
+  <label>Dispositivo:
+    <select [(ngModel)]="selectedDevice" (change)="onSelectDevice()">
+      <option *ngFor="let d of devices" [ngValue]="d">{{d.name}} ({{d.status}})</option>
+    </select>
+  </label>
+  <div id="map" class="map"></div>
+</div>

--- a/src/app/dashboard.component.ts
+++ b/src/app/dashboard.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import * as L from 'leaflet';
+import { DeviceService, Device, LocationPoint } from './device.service';
+
+interface DeviceWithStatus extends Device {
+  status: 'active' | 'inactive';
+}
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.css']
+})
+export class DashboardComponent implements OnInit {
+  devices: DeviceWithStatus[] = [];
+  selectedDevice?: DeviceWithStatus;
+  history: LocationPoint[] = [];
+  map?: L.Map;
+  lastMarker?: L.Marker;
+
+  constructor(private deviceService: DeviceService) {}
+
+  ngOnInit() {
+    this.loadDevices();
+  }
+
+  private loadDevices() {
+    this.deviceService.getDevices().subscribe(devices => {
+      this.devices = devices.map(d => ({
+        ...d,
+        status: this.isActive(d.lastSeen) ? 'active' : 'inactive'
+      }));
+    });
+  }
+
+  private isActive(lastSeen: string): boolean {
+    const last = new Date(lastSeen);
+    const diff = Date.now() - last.getTime();
+    return diff <= 20 * 60 * 1000;
+  }
+
+  onSelectDevice() {
+    if (!this.selectedDevice) return;
+    this.deviceService.getDeviceHistory(this.selectedDevice.id).subscribe(history => {
+      this.history = history;
+      this.renderMap();
+    });
+  }
+
+  private renderMap() {
+    if (!this.history.length) return;
+    if (!this.map) {
+      this.map = L.map('map').setView([this.history[0].lat, this.history[0].lng], 13);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '© OpenStreetMap contributors'
+      }).addTo(this.map);
+    } else {
+      this.map.setView([this.history[0].lat, this.history[0].lng], 13);
+      this.map.eachLayer(layer => {
+        if ((layer as L.Marker).getLatLng) {
+          this.map!.removeLayer(layer);
+        }
+      });
+    }
+
+    this.history.forEach(point => {
+      L.circleMarker([point.lat, point.lng]).addTo(this.map!);
+    });
+
+    const last = this.history[this.history.length - 1];
+    this.lastMarker = L.marker([last.lat, last.lng]).addTo(this.map!);
+    this.lastMarker.bindPopup('Última posición').openPopup();
+  }
+}

--- a/src/app/device.service.ts
+++ b/src/app/device.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface Device {
+  id: string;
+  name: string;
+  lastSeen: string;
+}
+
+export interface LocationPoint {
+  lat: number;
+  lng: number;
+  timestamp: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class DeviceService {
+  private apiUrl = 'http://localhost:3000'; // Ajuste según backend
+
+  constructor(private http: HttpClient) {}
+
+  getDevices(): Observable<Device[]> {
+    return this.http.get<Device[]>(`${this.apiUrl}/devices`);
+  }
+
+  getDeviceHistory(id: string): Observable<LocationPoint[]> {
+    return this.http.get<LocationPoint[]>(`${this.apiUrl}/devices/${id}/locations`);
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>MDM Dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <style>
+    html, body, app-root {
+      height: 100%;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <app-root></app-root>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,4 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent).catch(err => console.error(err));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["es2018", "dom"],
+    "typeRoots": ["node_modules/@types"],
+    "allowSyntheticDefaultImports": true,
+    "useDefineForClassFields": false
+  },
+  "files": ["src/main.ts"],
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,37 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+
+module.exports = {
+  entry: './src/main.ts',
+  mode: 'development',
+  devtool: 'source-map',
+  resolve: {
+    extensions: ['.ts', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: 'ts-loader',
+        exclude: /node_modules/
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './src/index.html'
+    })
+  ],
+  devServer: {
+    port: 4200,
+    historyApiFallback: true
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist')
+  }
+};


### PR DESCRIPTION
## Summary
- initialize Angular project config
- add Leaflet-based dashboard component
- add device service for backend calls
- document setup steps in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841d9cf47c08330a5808c028e53e2a0