### PR TITLE
Add comprehensive .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Node dependencies
+node_modules/
+jspm_packages/
+
+# Build outputs
+/dist/
+build/
+out/
+/tmp/
+/temp/
+/out-tsc/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage reports
+coverage/
+*.lcov
+.nyc_output/
+
+# Compiled TypeScript
+*.tsbuildinfo
+
+# Environment files
+.env
+.env.*
+
+# IDE directories
+.idea/
+.vscode/
+
+# Cache directories
+.npm/
+.yarn/
+.pnp.*
+.cache/
+
+# OS-generated files
+.DS_Store
+Thumbs.db
+


### PR DESCRIPTION
## Summary
- add a robust `.gitignore` for Node and TypeScript builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841dc066f388330afd61537f304c2be