### PR TITLE
Add sidebar component with device filtering

### DIFF
--- a/src/app/features/dashboard/dashboard.component.css
+++ b/src/app/features/dashboard/dashboard.component.css
@@ -6,10 +6,11 @@
 .dashboard {
   height: 100vh;
   width: 100%;
+  display: flex;
 }
 
 #map {
   height: 100%;
-  width: 100%;
+  flex: 1;
   background-color: #eee;
 }

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -1,3 +1,4 @@
 <div class="dashboard">
+  <app-sidebar (deviceSelected)="onDeviceSelected($event)"></app-sidebar>
   <div class="map" id="map"></div>
 </div>

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -1,16 +1,28 @@
 import { Component, AfterViewInit } from '@angular/core';
 import * as L from 'leaflet';
+import { CommonModule } from '@angular/common';
+import { DeviceService } from '../../core/services/device.service';
+import { Device } from '../../core/models/device';
+import { SidebarComponent } from './sidebar/sidebar.component';
 
 @Component({
   selector: 'app-dashboard',
+  standalone: true,
+  imports: [CommonModule, SidebarComponent],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'],
 })
 export class DashboardComponent implements AfterViewInit {
   private map?: L.Map;
+  private markers: Record<string, L.Layer> = {};
+  devices: Device[] = [];
+  selectedId = 'all';
+
+  constructor(private readonly deviceService: DeviceService) {}
 
   ngAfterViewInit(): void {
     this.initMap();
+    this.loadDevices();
     setTimeout(() => {
       this.map?.invalidateSize();
     }, 0);
@@ -35,5 +47,49 @@ export class DashboardComponent implements AfterViewInit {
     requestAnimationFrame(() => {
       this.map?.invalidateSize();
     });
+  }
+
+  private loadDevices(): void {
+    this.deviceService.getDevices().subscribe((devices) => {
+      this.devices = devices;
+      this.createMarkers();
+    });
+  }
+
+  private createMarkers(): void {
+    if (!this.map) return;
+    this.devices.forEach((device) => {
+      const lastSeen = new Date(device.lastSeen).getTime();
+      const diff = Date.now() - lastSeen;
+      const recent = diff <= 20 * 60 * 1000;
+      const marker = L.circleMarker([device.lat, device.lng], {
+        radius: 8,
+        color: recent ? 'green' : 'red',
+        fillColor: recent ? 'green' : 'red',
+        fillOpacity: 1,
+      }).bindPopup(device.name);
+      this.markers[device.id] = marker;
+    });
+    this.updateMarkers();
+  }
+
+  onDeviceSelected(id: string): void {
+    this.selectedId = id;
+    this.updateMarkers();
+  }
+
+  private updateMarkers(): void {
+    if (!this.map) return;
+    Object.values(this.markers).forEach((m) => this.map!.removeLayer(m));
+
+    if (this.selectedId === 'all') {
+      Object.values(this.markers).forEach((m) => m.addTo(this.map!));
+    } else {
+      const marker = this.markers[this.selectedId];
+      if (marker) {
+        marker.addTo(this.map!);
+        this.map!.setView((marker as any).getLatLng(), this.map.getZoom());
+      }
+    }
   }
 }

--- a/src/app/features/dashboard/sidebar/sidebar.component.css
+++ b/src/app/features/dashboard/sidebar/sidebar.component.css
@@ -1,0 +1,5 @@
+.sidebar {
+  padding: 1rem;
+  background: #f5f5f5;
+  width: 200px;
+}

--- a/src/app/features/dashboard/sidebar/sidebar.component.html
+++ b/src/app/features/dashboard/sidebar/sidebar.component.html
@@ -1,0 +1,9 @@
+<div class="sidebar">
+  <label for="device-select">Device</label>
+  <select id="device-select" [(ngModel)]="selectedId" (change)="onSelectionChange()">
+    <option value="all">All devices</option>
+    <option *ngFor="let device of devices" [value]="device.id">
+      {{ device.name }}
+    </option>
+  </select>
+</div>

--- a/src/app/features/dashboard/sidebar/sidebar.component.ts
+++ b/src/app/features/dashboard/sidebar/sidebar.component.ts
@@ -1,0 +1,31 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DeviceService } from '../../../core/services/device.service';
+import { Device } from '../../../core/models/device';
+
+@Component({
+  selector: 'app-sidebar',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './sidebar.component.html',
+  styleUrls: ['./sidebar.component.css'],
+})
+export class SidebarComponent implements OnInit {
+  devices: Device[] = [];
+  selectedId = 'all';
+
+  @Output() deviceSelected = new EventEmitter<string>();
+
+  constructor(private readonly deviceService: DeviceService) {}
+
+  ngOnInit(): void {
+    this.deviceService.getDevices().subscribe((devices) => {
+      this.devices = devices;
+    });
+  }
+
+  onSelectionChange(): void {
+    this.deviceSelected.emit(this.selectedId);
+  }
+}


### PR DESCRIPTION
## Summary
- add sidebar component for selecting devices
- display markers on map based on device last sync time
- allow filtering map markers via sidebar select

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424c1f5a3083308defced8aa5e47db