### PR TITLE
Improve map controls and sidebar

### DIFF
--- a/src/app/features/dashboard/dashboard.component.css
+++ b/src/app/features/dashboard/dashboard.component.css
@@ -9,6 +9,17 @@
   display: flex;
 }
 
+.map {
+  position: relative;
+}
+
+.toggle-sidebar-btn {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 1000;
+}
+
 #map {
   height: 100%;
   flex: 1;

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -1,4 +1,15 @@
 <div class="dashboard">
-  <app-sidebar (deviceSelected)="onDeviceSelected($event)"></app-sidebar>
-  <div class="map" id="map"></div>
+  <app-sidebar
+    *ngIf="sidebarVisible"
+    (deviceSelected)="onDeviceSelected($event)"
+  ></app-sidebar>
+  <div class="map" id="map">
+    <button
+      type="button"
+      class="btn btn-secondary toggle-sidebar-btn"
+      (click)="toggleSidebar()"
+    >
+      {{ sidebarVisible ? 'Ocultar menú' : 'Mostrar menú' }}
+    </button>
+  </div>
 </div>

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -17,6 +17,7 @@ export class DashboardComponent implements AfterViewInit {
   private markers: Record<string, L.Layer> = {};
   devices: Device[] = [];
   selectedId = 'all';
+  sidebarVisible = true;
 
   constructor(private readonly deviceService: DeviceService) {}
 
@@ -34,10 +35,12 @@ export class DashboardComponent implements AfterViewInit {
       zoom: 13,
       minZoom: 3,
       maxZoom: 18,
-      zoomControl: true,
+      zoomControl: false,
       maxBounds: L.latLngBounds(L.latLng(-90, -180), L.latLng(90, 180)),
       attributionControl: true,
     });
+
+    L.control.zoom({ position: 'bottomright' }).addTo(this.map);
 
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; OpenStreetMap contributors',
@@ -81,6 +84,11 @@ export class DashboardComponent implements AfterViewInit {
   onDeviceSelected(id: string): void {
     this.selectedId = id;
     this.updateMarkers();
+  }
+
+  toggleSidebar(): void {
+    this.sidebarVisible = !this.sidebarVisible;
+    setTimeout(() => this.map?.invalidateSize(), 0);
   }
 
   private updateMarkers(): void {

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,3 +8,16 @@ app-root {
   display: block;
   height: 100%;
 }
+
+/* Larger map controls for desktop */
+.leaflet-control-zoom-in,
+.leaflet-control-zoom-out {
+  width: 40px;
+  height: 40px;
+  line-height: 40px;
+  font-size: 1.5rem;
+}
+.leaflet-control-zoom {
+  margin-bottom: 1rem;
+  margin-right: 1rem;
+}


### PR DESCRIPTION
## Summary
- enlarge Leaflet zoom controls for desktop
- move map controls to bottom-right
- allow collapsing the sidebar

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438ab81a0c8330a6d8a69c856b191b