### PR TITLE
Add toolbar component

### DIFF
--- a/src/app/features/dashboard/dashboard.component.css
+++ b/src/app/features/dashboard/dashboard.component.css
@@ -13,13 +13,6 @@
   position: relative;
 }
 
-.toggle-sidebar-btn {
-  position: absolute;
-  top: 0.5rem;
-  left: 0.5rem;
-  z-index: 1000;
-}
-
 #map {
   height: 100%;
   flex: 1;

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -4,12 +4,9 @@
     (deviceSelected)="onDeviceSelected($event)"
   ></app-sidebar>
   <div class="map" id="map">
-    <button
-      type="button"
-      class="btn btn-secondary toggle-sidebar-btn"
-      (click)="toggleSidebar()"
-    >
-      {{ sidebarVisible ? 'Ocultar menú' : 'Mostrar menú' }}
-    </button>
+    <app-toolbar
+      [sidebarVisible]="sidebarVisible"
+      (toggle)="toggleSidebar()"
+    ></app-toolbar>
   </div>
 </div>

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -4,11 +4,12 @@ import { CommonModule } from '@angular/common';
 import { DeviceService } from '../../core/services/device.service';
 import { Device } from '../../core/models/device';
 import { SidebarComponent } from './sidebar/sidebar.component';
+import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [CommonModule, SidebarComponent],
+  imports: [CommonModule, SidebarComponent, ToolbarComponent],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'],
 })

--- a/src/app/shared/toolbar/toolbar.component.css
+++ b/src/app/shared/toolbar/toolbar.component.css
@@ -1,0 +1,6 @@
+.toolbar {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 1000;
+}

--- a/src/app/shared/toolbar/toolbar.component.html
+++ b/src/app/shared/toolbar/toolbar.component.html
@@ -1,0 +1,9 @@
+<div class="toolbar">
+  <button
+    type="button"
+    class="btn btn-secondary toggle-sidebar-btn"
+    (click)="onToggle()"
+  >
+    {{ sidebarVisible ? 'Ocultar menú' : 'Mostrar menú' }}
+  </button>
+</div>

--- a/src/app/shared/toolbar/toolbar.component.ts
+++ b/src/app/shared/toolbar/toolbar.component.ts
@@ -1,0 +1,18 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-toolbar',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './toolbar.component.html',
+  styleUrls: ['./toolbar.component.css'],
+})
+export class ToolbarComponent {
+  @Input() sidebarVisible = true;
+  @Output() toggle = new EventEmitter<void>();
+
+  onToggle(): void {
+    this.toggle.emit();
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone ToolbarComponent
- use ToolbarComponent in Dashboard to toggle sidebar
- tidy dashboard styles

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438c041b5c8330ad479daa872f4989