### PR TITLE
Implement layout with toolbar and sidebar

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,0 +1,38 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.toolbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  background: #1976d2;
+  color: #fff;
+  box-sizing: border-box;
+}
+
+.main-container {
+  display: flex;
+  height: calc(100% - 56px);
+  margin-top: 56px;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+}
+
+.menu-btn {
+  margin-right: 1rem;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.5rem;
+  cursor: pointer;
+}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,1 +1,10 @@
-<router-outlet></router-outlet>
+<div class="toolbar">
+  <button type="button" class="menu-btn" (click)="toggleSidebar()">&#9776;</button>
+  <span class="title">Sistema MDM</span>
+</div>
+<div class="main-container">
+  <app-sidebar *ngIf="showSidebar"></app-sidebar>
+  <div class="content">
+    <router-outlet></router-outlet>
+  </div>
+</div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,12 +1,20 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { RouterOutlet } from '@angular/router';
+import { SidebarComponent } from './features/dashboard/sidebar/sidebar.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  standalone: true,
+  imports: [CommonModule, RouterOutlet, SidebarComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })
 export class App {
   protected title = 'mdm-dashboard';
+  showSidebar = true;
+
+  toggleSidebar(): void {
+    this.showSidebar = !this.showSidebar;
+  }
 }

--- a/src/app/features/dashboard/dashboard.component.css
+++ b/src/app/features/dashboard/dashboard.component.css
@@ -5,7 +5,7 @@
 
 .dashboard {
   position: relative;
-  height: 100vh;
+  height: 100%;
   width: 100%;
   display: flex;
 }

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -1,11 +1,3 @@
 <div class="dashboard">
-  <app-toolbar
-    [sidebarVisible]="sidebarVisible"
-    (toggle)="toggleSidebar()"
-  ></app-toolbar>
-  <app-sidebar
-    *ngIf="sidebarVisible"
-    (deviceSelected)="onDeviceSelected($event)"
-  ></app-sidebar>
   <div class="map" id="map"></div>
 </div>

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -3,13 +3,11 @@ import * as L from 'leaflet';
 import { CommonModule } from '@angular/common';
 import { DeviceService } from '../../core/services/device.service';
 import { Device } from '../../core/models/device';
-import { SidebarComponent } from './sidebar/sidebar.component';
-import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [CommonModule, SidebarComponent, ToolbarComponent],
+  imports: [CommonModule],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'],
 })
@@ -18,7 +16,6 @@ export class DashboardComponent implements AfterViewInit {
   private markers: Record<string, L.Layer> = {};
   devices: Device[] = [];
   selectedId = 'all';
-  sidebarVisible = true;
 
   constructor(private readonly deviceService: DeviceService) {}
 
@@ -87,10 +84,6 @@ export class DashboardComponent implements AfterViewInit {
     this.updateMarkers();
   }
 
-  toggleSidebar(): void {
-    this.sidebarVisible = !this.sidebarVisible;
-    setTimeout(() => this.map?.invalidateSize(), 0);
-  }
 
   private updateMarkers(): void {
     if (!this.map) return;

--- a/src/app/features/dashboard/sidebar/sidebar.component.css
+++ b/src/app/features/dashboard/sidebar/sidebar.component.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;  /* Centra horizontalmente los hijos */
-  height: 100vh;
+  height: 100%;
   width: 250px;
   background: #f5f5f5;
   padding: 1rem;

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,6 +7,7 @@ html, body {
 app-root {
   display: block;
   height: 100%;
+  margin: 0;
 }
 
 /* Larger map controls for desktop */


### PR DESCRIPTION
## Summary
- add application layout with fixed toolbar and sidebar
- adjust dashboard to render only the map
- tweak sidebar styles
- update global styles

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439885f09c8330a6f4fb2857b30fdb